### PR TITLE
Filter null fields in array

### DIFF
--- a/Object/AbstractObject.php
+++ b/Object/AbstractObject.php
@@ -96,6 +96,10 @@ abstract class AbstractObject
                 continue;
             }
 
+            if ($value === NULL) {
+                continue;
+            }
+
             if ('unmappedFields' === $property) {
                 foreach ($value as $unmappedProperty => $unmappedValue) {
                     if (true === in_array($unmappedProperty, $writeProtectedFields)) {


### PR DESCRIPTION
Filtering NULL values from arrays since Salesforce does not accept some IDs as NULL which are already in your derivatives of AbstractObject (e.g. PricebookEntry, Product)